### PR TITLE
사용자 로그인정보 추가

### DIFF
--- a/src/main/java/com/hrm/dao/UserAccountDao.java
+++ b/src/main/java/com/hrm/dao/UserAccountDao.java
@@ -1,12 +1,29 @@
 package com.hrm.dao;
 
+import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Param;
-import org.apache.ibatis.annotations.Select;
 
 import com.hrm.dto.UserAccountDto;
 
 @Mapper
 public interface UserAccountDao {
 	UserAccountDto findByEmployeeId(@Param("employeeId") String employeeId);
+
+	@Insert({ """
+			INSERT INTO UserAccounts(
+				EmployeeID,
+				Username,
+				Password,
+				Role
+			) VALUES(
+				#{EmployeeID},
+				#{Username},
+				#{Password},
+				#{Role}
+			)
+			""" })
+	@Options(useGeneratedKeys = true, keyProperty = "UserID")
+	int addUserAccount(UserAccountDto userAccountDto);
 }

--- a/src/main/java/com/hrm/dao/UserAccountDao.java
+++ b/src/main/java/com/hrm/dao/UserAccountDao.java
@@ -18,12 +18,12 @@ public interface UserAccountDao {
 				Password,
 				Role
 			) VALUES(
-				#{EmployeeID},
-				#{Username},
-				#{Password},
-				#{Role}
+				#{employeeId},
+				#{username},
+				#{password},
+				#{role}
 			)
 			""" })
-	@Options(useGeneratedKeys = true, keyProperty = "UserID")
+	@Options(useGeneratedKeys = true, keyProperty = "userId")
 	int addUserAccount(UserAccountDto userAccountDto);
 }

--- a/src/main/java/com/hrm/dto/EmployeeDto.java
+++ b/src/main/java/com/hrm/dto/EmployeeDto.java
@@ -16,6 +16,12 @@ public class EmployeeDto {
 	private String gender; // 성별
 	private Integer departmentId; // 부서번호
 	private Position position; // 직급
+
+	// position 의 한글 설명을 반환하는 getter
+	public String getPositionName() {
+		return position != null ? position.getPosition() : null;
+	}
+
 	private LocalDate hiredate; // 입사일
 	private String status; // 재직상태(Active 재직, Inactive 휴직, Retirement 퇴사)
 	private String phonenumber; // 핸드폰

--- a/src/main/java/com/hrm/dto/EmployeeDto.java
+++ b/src/main/java/com/hrm/dto/EmployeeDto.java
@@ -2,6 +2,8 @@ package com.hrm.dto;
 
 import java.time.LocalDate;
 
+import com.hrm.enums.Position;
+
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -13,14 +15,14 @@ public class EmployeeDto {
 	private LocalDate dateOfBirth; // 생일
 	private String gender; // 성별
 	private Integer departmentId; // 부서번호
-	private String position; // 직급
+	private Position position; // 직급
 	private LocalDate hiredate; // 입사일
 	private String status; // 재직상태(Active 재직, Inactive 휴직, Retirement 퇴사)
 	private String phonenumber; // 핸드폰
 	private String email; // 이메일
-	
+
 	// ------------------------- 추가
-	
+
 	private String departmentName; // 부서 이름
 	private DepartmentDto department; // 부서정보 매핑
 }

--- a/src/main/java/com/hrm/dto/UserAccountDto.java
+++ b/src/main/java/com/hrm/dto/UserAccountDto.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 public class UserAccountDto {
 
 	private Integer userId; // 사용자 id
-	private Integer employeeId; // 사원 id
+	private String employeeId; // 사원 id (이메일로 저장되기때문에 integer -> string)
 	private String username; // 사용자 이름
 	private String password; // 사용자 비밀번호, Spring security로 암호화 예정
 	private Role role; // 권한(관리자 or 인사팀)

--- a/src/main/java/com/hrm/enums/Position.java
+++ b/src/main/java/com/hrm/enums/Position.java
@@ -1,0 +1,21 @@
+package com.hrm.enums;
+
+public enum Position {
+	INTERN("인턴"),
+	STAFF("사원"), 
+	SENIOR("주임"),
+	ASSISTANT_MANAGER("대리"),
+	MANAGER("과장"), 
+	SENIOR_MANAGER("차장"),
+	DEPUTY_GENERAL_MANAGER("부장");
+
+	private final String position;
+
+	Position(String position) {
+		this.position = position;
+	}
+
+	public String getPosition() {
+		return this.position;
+	}
+}

--- a/src/main/java/com/hrm/enums/Role.java
+++ b/src/main/java/com/hrm/enums/Role.java
@@ -1,7 +1,7 @@
 package com.hrm.enums;
 
 public enum Role {
-    Admin, Employee, HR;
+    ADMIN, EMPLOYEE, HR;
 
     public String getAuthority() {
         return "ROLE_" + this.name();

--- a/src/main/java/com/hrm/service/EmployeeService.java
+++ b/src/main/java/com/hrm/service/EmployeeService.java
@@ -2,11 +2,16 @@ package com.hrm.service;
 
 import java.util.List;
 
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.hrm.dao.EmployeeDao;
+import com.hrm.dao.UserAccountDao;
 import com.hrm.dto.DepartmentDto;
 import com.hrm.dto.EmployeeDto;
+import com.hrm.dto.UserAccountDto;
+import com.hrm.enums.Role;
 
 import lombok.RequiredArgsConstructor;
 
@@ -15,6 +20,8 @@ import lombok.RequiredArgsConstructor;
 public class EmployeeService {
 
 	private final EmployeeDao employeeDao;
+	private final UserAccountDao userAccountDao;
+	private final PasswordEncoder passwordEncoder;
 
 	// 사원 리스트 (사원번호, 사원이름, 부서이름)
 	public List<EmployeeDto> employeesList(int offset, int page) {
@@ -36,12 +43,32 @@ public class EmployeeService {
 		return employeeDao.departmentList();
 	}
 
-	// 사원 추가
+	/*
+	 * 사원 추가. 
+	 * Employee, UserAccounts 두개의 테이블에 INSERT 해야하므로 트랜잭션 처리!
+	 */
+	@Transactional
 	public EmployeeDto addEmployee(EmployeeDto employeeDto) {
 		// 사원을 추가하고
 		int result = employeeDao.addEmployee(employeeDto);
 
 		if (result > 0) {
+			// UserAccount에 추가하기 위한 UserAccountsDto 생성하고
+			UserAccountDto userAccountDto = new UserAccountDto();
+			userAccountDto.setEmployeeId(employeeDto.getEmployeeId());
+			userAccountDto.setUsername(employeeDto.getName());
+			userAccountDto.setPassword(passwordEncoder.encode("1234")); // PasswordEncoder를 이용한 비밀번호 암호화
+
+			// 인사부원은 "HR"권한 부여하고
+			if (employeeDto.getDepartment().getDepartmentname().equals("인사부")) {
+				userAccountDto.setRole(Role.HR);
+			} else {
+				userAccountDto.setRole(Role.Employee);
+			}
+			
+			// UserAccount 테이블에 사원 로그인정보 추가
+			userAccountDao.addUserAccount(userAccountDto);
+
 			// 추가된 사원의 정보를 반환
 			return employeeDao.employeesDetail(employeeDto.getEmployeeId());
 		}

--- a/src/main/java/com/hrm/service/EmployeeService.java
+++ b/src/main/java/com/hrm/service/EmployeeService.java
@@ -44,8 +44,8 @@ public class EmployeeService {
 	}
 
 	/*
-	 * 사원 추가. 
-	 * Employee, UserAccounts 두개의 테이블에 INSERT 해야하므로 트랜잭션 처리!
+	 * 사원 추가.
+	 *  Employee, UserAccounts 두개의 테이블에 INSERT 해야하므로 트랜잭션 처리!
 	 */
 	@Transactional
 	public EmployeeDto addEmployee(EmployeeDto employeeDto) {
@@ -55,17 +55,17 @@ public class EmployeeService {
 		if (result > 0) {
 			// UserAccount에 추가하기 위한 UserAccountsDto 생성하고
 			UserAccountDto userAccountDto = new UserAccountDto();
-			userAccountDto.setEmployeeId(employeeDto.getEmployeeId());
+			userAccountDto.setEmployeeId(employeeDto.getEmail());
 			userAccountDto.setUsername(employeeDto.getName());
 			userAccountDto.setPassword(passwordEncoder.encode("1234")); // PasswordEncoder를 이용한 비밀번호 암호화
 
 			// 인사부원은 "HR"권한 부여하고
-			if (employeeDto.getDepartment().getDepartmentname().equals("인사부")) {
+			if (employeeDto.getDepartmentId() != null && employeeDto.getDepartmentId() == 1) { // 인사부의 부서아이디는 1
 				userAccountDto.setRole(Role.HR);
 			} else {
-				userAccountDto.setRole(Role.Employee);
+				userAccountDto.setRole(Role.EMPLOYEE);
 			}
-			
+
 			// UserAccount 테이블에 사원 로그인정보 추가
 			userAccountDao.addUserAccount(userAccountDto);
 

--- a/src/main/resources/static/js/components/table.js
+++ b/src/main/resources/static/js/components/table.js
@@ -124,7 +124,7 @@ export function updateDetailView(employee) {
 	document.getElementById('empDob').textContent = formatDate(employee.dateOfBirth) ?? '';
 	document.getElementById('empGender').textContent = formatGender(employee.gender) ?? '';
 	document.getElementById('empDepartment').textContent = employee.department?.departmentname ?? '(부서정보없음)';
-	document.getElementById('empPosition').textContent = employee.position ?? '';
+	document.getElementById('empPosition').textContent = employee.positionName ?? '';
 	document.getElementById('empHireDate').textContent = formatDate(employee.hiredate) ?? '';
 	document.getElementById('empStatus').textContent = formatStatus(employee.status) ?? '';
 	document.getElementById('empPhoneNumber').textContent = employee.phonenumber ?? '';

--- a/src/main/resources/templates/employee/index.html
+++ b/src/main/resources/templates/employee/index.html
@@ -105,9 +105,17 @@
 	                    </select>
 	                </div>
 	                <div class="form-group">
-	                    <label for="position">직급</label>
-	                    <input type="text" id="position" name="position">
-	                </div>
+					    <label for="position">직급</label>
+					    <select id="position" name="position" required>
+					    	<option value="INTERN">인턴</option>
+					        <option value="STAFF">사원</option>
+					        <option value="SENIOR">주임</option>
+					        <option value="ASSISTANT_MANAGER">대리</option>
+					        <option value="MANAGER">과장</option>
+					        <option value="SENIOR_MANAGER">차장</option>
+					        <option value="DEPUTY_GENERAL_MANAGER">부장</option>
+					    </select>
+					</div>
 	                <div class="form-group">
 	                    <label for="hiredate">입사일</label>
 	                    <input type="date" id="hiredate" name="hiredate" required>


### PR DESCRIPTION
## #️⃣연관된 이슈

Feature #17 

## 📝작업 내용

- 직책 ENUM으로 고정 (클라이언트에서 select로 선택)
- 사원 등록 시 입력한 부서id로 차등 권한 부여('EMPLOYEE', 'HR')
- 사용자 아이디를 Employee테이블의 이메일로 설정.
- 사용자 비밀번호를 1234로 초기 기본 설정.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
